### PR TITLE
Option to turn off address lookup

### DIFF
--- a/classes/gateways/payer-direct-invoice-gateway.php
+++ b/classes/gateways/payer-direct-invoice-gateway.php
@@ -29,7 +29,7 @@ class Payer_Direct_Invoice_Gateway extends Payer_Factory_Gateway {
 
 		add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, array( $this, 'process_admin_options' ) );
 
-		add_filter( 'woocommerce_page_wc-settings', array( $this, 'show_keys_in_settings' ) );				
+		// add_filter( 'woocommerce_page_wc-settings', array( $this, 'show_keys_in_settings' ) );				
 	}
 
 	public function process_payment( $order_id ) {

--- a/classes/gateways/payer-factory-gateway.php
+++ b/classes/gateways/payer-factory-gateway.php
@@ -56,15 +56,18 @@ class Payer_Factory_Gateway extends WC_Payment_Gateway {
 	}
 
 	public function add_pno_field( $fields ) {
-		$fields['billing']['billing_pno'] = array(
-			'label'     	=> __('Personal number', 'payer-for-woocommerce'),
-			'placeholder'   => _x('xxxxxx-xxxx', 'placeholder', 'payer-for-woocommerce'),
-			'required'  	=> false,
-			'class'     	=> array('form-row-wide'),
-			'clear'     	=> true
-		 );
+		$payer_settings = get_option( 'woocommerce_payer_card_payment_settings' );
+		if($payer_settings['address_lookup'] === 'yes') {
+			$fields['billing']['billing_pno'] = array(
+				'label'     	=> __('Personal number', 'payer-for-woocommerce'),
+				'placeholder'   => _x('xxxxxx-xxxx', 'placeholder', 'payer-for-woocommerce'),
+				'required'  	=> false,
+				'class'     	=> array('form-row-wide'),
+				'clear'     	=> true
+			);
+		}
 	
-		 return $fields;
+		return $fields;
 	}
 
 	public function set_icon() {

--- a/includes/payer-factory-settings.php
+++ b/includes/payer-factory-settings.php
@@ -176,6 +176,18 @@ if ( $this->id === 'payer_card_payment' ) {
 		'desc_tip'      => true,
 	);
 
+	$settings['address_lookup_settings_title'] = array(
+		'title' => __( 'Address Lookup Settings', 'payer-for-woocommerce' ),
+		'type'  => 'title',
+	);
+
+	$settings['address_lookup'] = array(
+		'title' => __( 'Address lookup' ),
+		'type' => 'checkbox',
+		'label' => __( 'Add the address lookup form to checkout.', 'payer-for-woocommerce' ),
+		'default' => 'no'
+	);
+
 	$settings['test_mode_settings_title'] = array(
 		'title' => __( 'Test Mode Settings', 'payer-for-woocommerce' ),
 		'type'  => 'title',

--- a/payer-for-woocommerce.php
+++ b/payer-for-woocommerce.php
@@ -135,7 +135,10 @@ if ( ! class_exists( 'Payer_For_Woocommerce' ) ) {
 
 			wp_localize_script( 'payer_checkout', 'payer_checkout_params', $checkout_localize_params );
 
-			wp_enqueue_script( 'payer_checkout' );
+			$payer_settings = get_option( 'woocommerce_payer_card_payment_settings' );
+			if($payer_settings['address_lookup'] === 'yes') {
+				wp_enqueue_script( 'payer_checkout' );
+			}
 
 			$payer_masterpass_settings = get_option( 'woocommerce_payer_masterpass_settings' );
 			if ( 'yes' === $payer_masterpass_settings['instant_masterpass_checkout'] && ( is_product() || is_cart() || is_shop() || is_product_category() ) ) {


### PR DESCRIPTION
The address lookup functionality messes around with the order of checkout fields using javascript. It would be preferable if it was all done with wordpress hooks instead or only added its own fields instead of moving the default ones. We added an option to turn this functionality off. The option can be found under WooCommerce -> Settings -> Checkout -> Payer Card Payment.

Also commented out an unused hook that caused a warning to appear in the UI.