### PR TITLE
V 1.1.6

### DIFF
--- a/classes/gateways/payer-factory-gateway.php
+++ b/classes/gateways/payer-factory-gateway.php
@@ -41,7 +41,7 @@ class Payer_Factory_Gateway extends WC_Payment_Gateway {
 
 		update_post_meta( $order_id, apply_filters( 'payer_billing_pno_meta_name', '_billing_pno' ), apply_filters( 'payer_pno_field_data', $_POST['billing_pno'] ) );
 
-		$checkout_url = WC()->cart->get_checkout_url();
+		$checkout_url = wc_get_checkout_url();
 
 		$redirect_url = add_query_arg(
 			array(

--- a/classes/payer-class-ajax.php
+++ b/classes/payer-class-ajax.php
@@ -153,7 +153,7 @@ class Payer_Ajax extends WC_AJAX {
 
 			Payer_Masterpass_Populate_Order::set_gateway( $order );
 
-			$redirect_url = WC()->cart->get_checkout_url();
+			$redirect_url = wc_get_checkout_url();
 
 			$redirect_url = add_query_arg(
 				array(

--- a/classes/payer-class-ajax.php
+++ b/classes/payer-class-ajax.php
@@ -1,11 +1,11 @@
-<?php 
+<?php
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
 
 /**
  * Payer Ajax class.
- * 
+ *
  * @class    Payer_Ajax
  * @package  Payer/Classes
  * @category Class
@@ -19,18 +19,18 @@ class Payer_Ajax extends WC_AJAX {
 	 */
 	public static function init() {
 		self::add_ajax_events();
-    }
+	}
 
 	/**
 	 * Adds ajax events.
 	 *
 	 * @return void
 	 */
-    public static function add_ajax_events() {
+	public static function add_ajax_events() {
 			$ajax_events = array(
-				'get_address' 				=> true,
-				'instant_product_purchase'	=> true,
-				'instant_cart_purchase'		=> true,
+				'get_address'              => true,
+				'instant_product_purchase' => true,
+				'instant_cart_purchase'    => true,
 			);
 			foreach ( $ajax_events as $ajax_event => $nopriv ) {
 				add_action( 'wp_ajax_woocommerce_' . $ajax_event, array( __CLASS__, $ajax_event ) );
@@ -40,26 +40,26 @@ class Payer_Ajax extends WC_AJAX {
 					add_action( 'wc_ajax_' . $ajax_event, array( __CLASS__, $ajax_event ) );
 				}
 			}
-    }
-	
+	}
+
 	/**
 	 * Get Address Ajax event.
 	 *
 	 * @return void
 	 */
-    public static function get_address() {
+	public static function get_address() {
 			$personal_number = $_POST['personal_number'];
-			if( $personal_number !== '' ) {
-			if( '' !== $_POST['zip_code'] ) {
+		if ( $personal_number !== '' ) {
+			if ( '' !== $_POST['zip_code'] ) {
 				$zip_code = $_POST['zip_code'];
 			} else {
 				$zip_code = 12345;
 			}
 
 			$payer_address_information = Payer_Get_Address::get_address( $personal_number, $zip_code );
-			if( 'invalid request' === $payer_address_information['status'] ) {
+			if ( 'invalid request' === $payer_address_information['status'] ) {
 				$return = array(
-					'message' => __( 'Invalid request, please check the information or fill in the address manually.', 'payer-for-woocommerce' )
+					'message' => __( 'Invalid request, please check the information or fill in the address manually.', 'payer-for-woocommerce' ),
 				);
 				wp_send_json_error( $return );
 				wp_die();
@@ -68,35 +68,35 @@ class Payer_Ajax extends WC_AJAX {
 				krokedil_log_events( null, 'Payer Get Address Response', $payer_address_information );
 				$return = array(
 					'address_information' => $payer_address_information,
-					'message'			  => __( 'Address found and added to the checkout form', 'payer-for-woocommerce' )
+					'message'             => __( 'Address found and added to the checkout form', 'payer-for-woocommerce' ),
 				);
 				wp_send_json_success( $return );
 				wp_die();
 			}
 		} else {
 			$return = array(
-				'message' => __( 'Please fill in the personal number field', 'payer-for-woocommerce' )
+				'message' => __( 'Please fill in the personal number field', 'payer-for-woocommerce' ),
 			);
 			wp_send_json_error( $return );
 			wp_die();
 		}
 	}
-	
+
 	/**
 	 * Sets address as session.
 	 *
 	 * @param array $payer_address_information
-	 * 
+	 *
 	 * @return void
 	 */
 	private static function set_address( $payer_address_information ) {
 		$payer_customer_details = array(
-				'first_name'	=>	$payer_address_information['first_name'],
-				'last_name'		=>	$payer_address_information['last_name'],
-				'address_1'		=>	$payer_address_information['address_1'],
-				'address_2'		=> 	$payer_address_information['address_2'],
-				'company'		=>	$payer_address_information['company'],
-				'city'			=>	$payer_address_information['city'],
+			'first_name' => $payer_address_information['first_name'],
+			'last_name'  => $payer_address_information['last_name'],
+			'address_1'  => $payer_address_information['address_1'],
+			'address_2'  => $payer_address_information['address_2'],
+			'company'    => $payer_address_information['company'],
+			'city'       => $payer_address_information['city'],
 		);
 
 		WC()->session->set( 'payer_customer_details', $payer_customer_details );
@@ -108,28 +108,28 @@ class Payer_Ajax extends WC_AJAX {
 	 * @return void
 	 */
 	public static function instant_product_purchase() {
-		$product_id 	= $_POST['product_id'];
-		$variation_id 	= $_POST['variation_id'];
-		$quantity 		= $_POST['quantity'];
+		$product_id   = $_POST['product_id'];
+		$variation_id = $_POST['variation_id'];
+		$quantity     = $_POST['quantity'];
 		// Empty the current cart to prevent incorrect orders.
 		WC()->cart->empty_cart();
-		WC()->session->set( 'chosen_payment_method', 'payer_masterpass' );	
+		WC()->session->set( 'chosen_payment_method', 'payer_masterpass' );
 		Payer_Masterpass_Populate_Order::add_item_to_cart( $product_id, $quantity, $variation_id );
 		Payer_Masterpass_Functions::maybe_add_campaign_fee();
 
-		$order 	= wc_create_order();
+		$order    = wc_create_order();
 		$order_id = $order->get_id();
 
 		Payer_Masterpass_Populate_Order::add_order_details( $order );
 
 		Payer_Masterpass_Populate_Order::set_gateway( $order );
 
-		$redirect_url = WC()->cart->get_checkout_url();
-		
+		$redirect_url = wc_get_checkout_url();
+
 		$redirect_url = add_query_arg(
 			array(
-				'payer-redirect'	=>	'1',
-				'order_id'			=>	$order_id,
+				'payer-redirect' => '1',
+				'order_id'       => $order_id,
 			),
 			$redirect_url
 		);
@@ -143,22 +143,22 @@ class Payer_Ajax extends WC_AJAX {
 	 * @return void
 	 */
 	public static function instant_cart_purchase() {
-		if ( WC()->cart->get_cart_contents_count() > 0 ) {	
-			WC()->session->set( 'chosen_payment_method', 'payer_masterpass' );	
+		if ( WC()->cart->get_cart_contents_count() > 0 ) {
+			WC()->session->set( 'chosen_payment_method', 'payer_masterpass' );
 			Payer_Masterpass_Functions::maybe_add_campaign_fee();
-			$order 	= wc_create_order();
+			$order    = wc_create_order();
 			$order_id = $order->get_id();
 
 			Payer_Masterpass_Populate_Order::add_order_details( $order );
-			
+
 			Payer_Masterpass_Populate_Order::set_gateway( $order );
 
 			$redirect_url = WC()->cart->get_checkout_url();
-			
+
 			$redirect_url = add_query_arg(
 				array(
-					'payer-redirect'	=>	'1',
-					'order_id'			=>	$order_id,
+					'payer-redirect' => '1',
+					'order_id'       => $order_id,
 				),
 				$redirect_url
 			);

--- a/classes/payer-class-post-checkout.php
+++ b/classes/payer-class-post-checkout.php
@@ -38,11 +38,13 @@ class Payer_Post_Checkout {
 				}
 
 				// Card payment subscription parent order.
-				if ( $order->get_payment_method() === 'payer_card_payment' && wcs_order_contains_subscription( $order, 'parent' ) ) {
-					$this->make_debit( $order_id );
+				if ( function_exists( 'wcs_order_contains_subscription' ) && function_exists( 'wcs_is_subscription' ) ) {
+					if ( $order->get_payment_method() === 'payer_card_payment' && wcs_order_contains_subscription( $order, 'parent' ) ) {
+						$this->make_debit( $order_id );
 
-					update_post_meta( $order_id, '_payer_order_completed', 'true' );
-					$order->add_order_note( __( 'The order has been completed with Payer', 'payer-for-woocommerce' ) );
+						update_post_meta( $order_id, '_payer_order_completed', 'true' );
+						$order->add_order_note( __( 'The order has been completed with Payer', 'payer-for-woocommerce' ) );
+					}
 				}
 
 				if ( $order->get_payment_method() === 'payer_direct_invoice_gateway' ) {

--- a/payer-for-woocommerce.php
+++ b/payer-for-woocommerce.php
@@ -8,7 +8,7 @@
  * Plugin Name:     Payer for WooCommerce
  * Plugin URI:      https://krokedil.se/payer/
  * Description:     Extends WooCommerce. Provides a <a href="https://https://www.payer.se/" target="_blank">Payer</a> checkout for WooCommerce.
- * Version:         1.1.5
+ * Version:         1.1.6
  * Author:          Krokedil
  * Author URI:      https://krokedil.se/
  * Developer:       Krokedil
@@ -17,7 +17,7 @@
  * Domain Path:     /languages
  *
  * WC requires at least: 3.0.0
- * WC tested up to: 4.0.1
+ * WC tested up to: 4.2.1
  *
  * Copyright:       © Krokedil Produktionsbyrå AB.
  * License:         GNU General Public License v3.0
@@ -137,7 +137,7 @@ if ( ! class_exists( 'Payer_For_Woocommerce' ) ) {
 			// Set URL.
 			define( 'PAYER_PLUGIN_URL', untrailingslashit( plugins_url( '/', __FILE__ ) ) );
 			// Set version number.
-			define( 'PAYER_VERSION_NUMBER', '1.1.5' );
+			define( 'PAYER_VERSION_NUMBER', '1.1.6' );
 			// Set path to SDK.
 			define( 'PAYER_SDK_DIR', '/vendor/' );
 			// Set Krokedil Logger Defines.

--- a/readme.txt
+++ b/readme.txt
@@ -2,11 +2,11 @@
 Contributors: payertech, krokedil, NiklasHogefjord
 Tags: ecommerce, e-commerce, woocommerce, payer, checkout
 Requires at least: 4.7
-Tested up to: 5.4.1
+Tested up to: 5.4.2
 Requires PHP: 5.6
 Stable tag: trunk
 WC requires at least: 3.0.0
-WC tested up to: 4.0.1
+WC tested up to: 4.2.1
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -37,6 +37,10 @@ For help setting up and configuring Payer for WooCommerce please refer to our [d
 
 
 == CHANGELOG ==
+= 2020.06.23  	- version 1.1.6 =
+* Fix	        - Avoid fatal error - check if wcs_order_contains_subscription exist in payer_order_completed function.
+* Fix           - Use wc_get_checkout_url() instead of WC()->cart->get_checkout_url() to avoid deprecated notice.
+
 = 2020.05.05  	- version 1.1.5 =
 * Fix	        - Fix for disabled Payer payment gateway still showing on checkout.
 


### PR DESCRIPTION
* Fix	 - Avoid fatal error - check if wcs_order_contains_subscription exist in payer_order_completed function.
* Fix - Use wc_get_checkout_url() instead of WC()->cart->get_checkout_url() to avoid deprecated notice.